### PR TITLE
Support Building on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ check_env:
 setup:
 	@if [ -f /etc/arch-release ]; then \
 		./setup_arch.sh; \
+	elif [[ $(shell uname -s) == Darwin ]]; then \
+		./setup_macos.sh; \
 	else \
 		echo "Manual setup required: Ensure cmake, ninja, and arm-none-eabi-gcc are installed."; \
 	fi

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ See [HARDWARE.md](HARDWARE.md) for more details.
 
 ### Build steps
 
-**Linux:**  
+#### Linux
 ```bash
 make
 ```
 
 Output: `./artifacts/` (MonstaTek_M1_v0800.elf, .bin, .hex)
 
-**STM32CubeIDE:**  
+#### #STM32CubeIDE
 Open the project and build in the IDE.
 
 **VS Code:**  

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ See [HARDWARE.md](HARDWARE.md) for more details.
 
 - **STM32CubeIDE 1.17+** (recommended), or  
 - **VS Code** with ARM GCC 14.2, CMake Tools, Cortex-Debug, and Ninja, or
-- **Linux** with ARM GCC toolchain and Ninja
+- **Linux** with ARM GCC toolchain and Ninja or
+- **MacOS** with ARM GCC toolchain, CMake Tools, and Ninja
 
 ### Build steps
 
@@ -58,6 +59,18 @@ Open the project and build in the IDE.
 2. Build via the Build icon  
 
 Output: `./out/build/gcc-14_2_build-release` (VS Code) or `./Release` (STM32CubeIDE)
+
+#### MacOS
+Get prerequisites
+```bash
+make setup
+```
+Build
+```bash
+make
+```
+
+Output: `./artifacts/`
 
 ## Contributing
 

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ cmake -G Ninja -B $BUILD_DIR \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
 echo "Compiling..."
-cmake --build $BUILD_DIR --parallel $(nproc)
+cmake --build $BUILD_DIR --parallel $(nproc 2>/dev/null || sysctl -n hw.ncpu)
 
 echo "Collecting artifacts to ./$OUTPUT_DIR"
 cp $BUILD_DIR/*.bin $BUILD_DIR/*.elf $BUILD_DIR/*.hex $OUTPUT_DIR/ 2>/dev/null || true

--- a/cmake/gcc-arm-none-eabi.cmake
+++ b/cmake/gcc-arm-none-eabi.cmake
@@ -8,9 +8,20 @@ set(CMAKE_CXX_COMPILER_FORCED TRUE)
 set(CMAKE_C_COMPILER_ID GNU)
 set(CMAKE_CXX_COMPILER_ID GNU)
 
+# Make things easier for macos, let the toolchain be found in a default location
+if(APPLE AND NOT DEFINED TOOLCHAIN_PATH)
+    file(GLOB ARM_TOOLCHAIN_VERSIONS "/Applications/ArmGNUToolchain/*/arm-none-eabi")
+    if(ARM_TOOLCHAIN_VERSIONS)
+        list(GET ARM_TOOLCHAIN_VERSIONS 0 FIRST_ARM_TOOLCHAIN)
+        set(TOOLCHAIN_PREFIX "${FIRST_ARM_TOOLCHAIN}/bin/arm-none-eabi-")
+    endif()
+endif()
+
 # Some default GCC settings
 # arm-none-eabi- must be part of path environment
-set(TOOLCHAIN_PREFIX                arm-none-eabi-)
+if(NOT DEFINED TOOLCHAIN_PREFIX)
+    set(TOOLCHAIN_PREFIX arm-none-eabi-)
+endif()
 
 set(CMAKE_C_COMPILER                ${TOOLCHAIN_PREFIX}gcc)
 set(CMAKE_ASM_COMPILER              ${CMAKE_C_COMPILER})

--- a/documentation/mbt.md
+++ b/documentation/mbt.md
@@ -8,6 +8,10 @@ The M1 firmware can be built with STM32CubeIDE or Visual Studio Code.
 
 Clone the repository. Install the required software and extensions:
 
+- For macOS users:
+  - [Install brew](https://brew.sh/)
+  - Install prereqs: `make setup`
+
 * For STM32CubeIDE users:
 
 - The code has been built with STM32CubeIDE 1.17.0.
@@ -53,7 +57,7 @@ ninja --version
 
 ## Build
 
-* For Linux users:
+* For macOS and Linux users:
 ```bash
 make
 ```
@@ -68,7 +72,7 @@ Build in the IDE.
 
 ## Build directories
 
-* For Linux users:
+* For macOS and Linux users:
 Firmware is built in the folder `./build/` with output copied to `./artifacts/`.
 
 * For Visual Studio Code users:

--- a/setup_macos.sh
+++ b/setup_macos.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "--- Preparing MacOS Build Environment ---"
+
+DEPENDS=(cmake ninja git arm-none-eabi-gcc gcc-arm-embedded srecord)
+
+if command -v brew >/dev/null 2>&1; then
+    echo "--- Installing dependencies from brew ---"
+    brew install ${DEPENDS[@]}
+fi
+
+echo "--- Dependency Setup complete. Rerun make  ---"


### PR DESCRIPTION
## Description
Added support for building on macOS.

The macOS version of ARM's toolchain appears to be using a different version of newlib, which may account for the slightly larger sized binary than what Arch is producing.

## Changes Made:
- `build.sh`: Support using sysctl to get the cpu count
- `Makefile` & `setup_macos.sh`: Gather dependencies from brew for Mac
- `cmake/gcc-arm-none-eabi.cmake`:
  - Allow setting `TOOLCHAIN_PREFIX` for all platforms
  - When `TOOLCHAIN_PREFIX` is unset on macos, try where brew puts it by default
- `documentation/mbt.md` & `README`: Document build
  - `README`: Split platform Build Steps via markdown headings

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing Environment
- IDE: N/A (command-line build)
- Version: N/A
- Compiler Hardware: M4 Max running 15.7.2
- Compiler: `arm-none-eabi-gcc (GCC) 15.2.0`
  - Also built/tested with 14.2, but that made the setup overly complicated since `brew`'s cask uses 15.2 now.
- Debugger: N/A

## How Has This Been Tested?
- [x] Build completes successfully with make
- [x] ELF file validated as ARMv8-M architecture
- [x] Binary/HEX files generated in artifacts directory
- [x] Memory usage within device limits (RAM: 26.88%, FLASH: 44.72%)
- [x] Moved the artifacts onto an SD card and went through
  - [x] `Settings`->`Firmware update`->`Image File`
  - [x] Selected the correct image from the SD card
  - [x] Checked that the versions displayed looked correct
  - [x] Selected `Firmware update` and watched until it said the update was successful
  - [x] Checked out that my M1 wasn't bricked.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings