### PR TITLE
fix(log): prevent formatter size wrap

### DIFF
--- a/m1_csrc/m1_log_debug.c
+++ b/m1_csrc/m1_log_debug.c
@@ -635,7 +635,7 @@ void m1_logdb_printf(S_M1_LogDebugLevel_t level, const char* tag, const char* fo
 static void m1_logdb_dyn_vsprintf(const char *format, va_list pargs, char **pstring)
 {
 	int ret_n;
-	uint8_t mem_size;
+	int mem_size;
 	va_list pargsc;
 
 	mem_size = M1_LOGDB_MESSAGE_SIZE; // Set the default size first


### PR DESCRIPTION
## Summary

Prevent `m1_logdb_dyn_vsprintf()` from truncating the dynamic buffer size through an 8-bit `uint8_t` temporary.

For certain oversized formatted outputs, `ret_n + 20` can exceed 255 and wrap back below the formatter's size cap. A 240-byte formatted result reproduces the repeated state deterministically: `240 + 20 -> 260 -> 4`, after which the formatter can repeat the same allocation/format cycle.

The fix is intentionally minimal:

```diff
- uint8_t mem_size;
+ int mem_size;
```

## Validation

- Independent host reproduction of the upstream size-wrap/repeated-state defect: PASS
- Corrected host behavior: PASS
- Paired ARM baseline/fixed builds with Arm GNU 14.2.Rel1: PASS
- Baseline warnings: 1076
- Fixed warnings: 1076 (`warning_delta=0`)
- Baseline/fixed build errors: 0
- Firmware artifact size delta: 0 bytes for BIN, CRC BIN, ELF, and HEX
- ELF memory footprint delta: `text=0`, `data=0`, `bss=0`
- Cold-rebuilt baseline reproduced the historical WP1 firmware artifacts byte-for-byte
- Fixed firmware rebuilt twice with byte-identical BIN, CRC BIN, ELF, and HEX artifacts

## Provenance

The issue was identified while reviewing reliability work in `bedge117/M1`, specifically commit `4fa1a463dee5c224cc590eb323806a369ea1b23a` (`C3.157: wedge-hardening pass ...`). The change here was independently reproduced against `Monstatek/M1` and reduced to the one-line root-cause correction above rather than copying the larger reference patch.
