### PR TITLE
fix(storage): preserve long filenames safely

### DIFF
--- a/m1_csrc/m1_file_browser.c
+++ b/m1_csrc/m1_file_browser.c
@@ -953,13 +953,14 @@ void m1_fb_deinit(void)
 /*
 *	This function dynamically concatenates number of strings given by num
 *	Each string is separated by the separator symbol given in separators
-*	Return: length of the new string
+*	Return: 1 on success, 0 if the resulting string is empty
 */
 /******************************************************************************/
 uint8_t m1_fb_dyn_strcat(char *buffer, uint8_t num, const char *format, ...)
 {
 	va_list pargs;
-	uint8_t len, k;
+	size_t len;
+	uint8_t k;
 	char *tmp_buffer;
 
 	assert(num >= 1);
@@ -996,6 +997,6 @@ uint8_t m1_fb_dyn_strcat(char *buffer, uint8_t num, const char *format, ...)
 	} // while (k)
 	va_end(pargs);
 
-	return strlen(buffer);
+	return 1;
 } // uint8_t m1_fb_dyn_strcat(char *buffer, uint8_t num, const char *format, ...)
 

--- a/m1_csrc/m1_storage.c
+++ b/m1_csrc/m1_storage.c
@@ -359,7 +359,7 @@ S_M1_file_info *storage_browse(void)
 	S_M1_Buttons_Status this_button_status;
 	S_M1_Main_Q_t q_item;
 	S_M1_file_info *f_info;
-	uint8_t error_stat, len;
+	uint8_t error_stat;
 	BaseType_t ret;
 
 	file_info.status = FB_OK;
@@ -461,13 +461,10 @@ S_M1_file_info *storage_browse(void)
 						{
 							//m1_fb_dyn_strcat(fullpath, 2, "",  f_info->dir_name, f_info->file_name);
 							file_info.file_is_selected = true;
-							strncpy(file_info.file_name, f_info->file_name, ESP_FILE_NAME_LEN_MAX);
-							strncpy(file_info.dir_name, f_info->dir_name, ESP_FILE_PATH_LEN_MAX);
-							len = strlen(f_info->file_name);
-							if ( len >= ESP_FILE_NAME_LEN_MAX )
-							{
-								strcpy(&file_info.file_name[len-4], "...");
-							}
+							strncpy(file_info.file_name, f_info->file_name, ESP_FILE_NAME_LEN_MAX - 1);
+							file_info.file_name[ESP_FILE_NAME_LEN_MAX - 1] = '\0';
+							strncpy(file_info.dir_name, f_info->dir_name, ESP_FILE_PATH_LEN_MAX - 1);
+							file_info.dir_name[ESP_FILE_PATH_LEN_MAX - 1] = '\0';
 							menu_setting_storage_exit();
 							break; // Exit and return to the calling task (subfunc_handler_task)
 						} // if ( f_info->file_is_selected )

--- a/m1_csrc/m1_storage.h
+++ b/m1_csrc/m1_storage.h
@@ -13,10 +13,10 @@
 #ifndef M1_STORAGE_H_
 #define M1_STORAGE_H_
 
-#define ESP_FILE_NAME_LEN_MAX	32
+#define ESP_FILE_NAME_LEN_MAX	256
 #define ESP_FILE_PATH_LEN_MAX	64
 
-#define FW_FILE_NAME_LEN_MAX	32
+#define FW_FILE_NAME_LEN_MAX	256
 #define FW_FILE_PATH_LEN_MAX	64
 
 void menu_setting_storage_init(void);


### PR DESCRIPTION
## Summary

Preserve FatFs long filenames selected through Storage/Firmware Update instead of corrupting the fixed 32-byte backing filename buffer.

The original selection path copied into a 32-byte destination and then, for long names, wrote `"..."` at `len - 4` using the source filename length. With a 38-character firmware filename, that offset is beyond the destination buffer; the same valid CRC firmware image was then rejected on-device as `Invalid image file!`.

This change:
- raises the ESP and firmware filename capacities from 32 to 256 bytes (`FF_MAX_LFN=255` plus NUL)
- uses bounded copies with explicit NUL termination
- removes the out-of-bounds ellipsis mutation from the operational filename
- uses `size_t` for dynamic path-length accounting while preserving the callers' nonzero-success contract

Directory path capacity remains 64 bytes; this PR does not claim arbitrary deep-path support.

## Validation

- Host ASan equivalent baseline: exact 38-character failing filename reproduced a stack-buffer-overflow (WRITE size 4)
- Patched ASan/UBSan: 38-character filename PASS
- FatFs 255-character filename boundary PASS
- Maximum constructed 319-character path PASS
- Paired Arm GNU 14.2.Rel1 baseline/fixed builds PASS
- Compiler warnings: 1075 -> 1075; build errors: 0 -> 0
- ELF text/data unchanged; BSS +224 bytes, exactly matching the static filename buffer increase from 32 to 256 bytes
- Canonical committed Linux/amd64 container build PASS
- Physical M1: exact committed firmware installed successfully
- Physical 49-character firmware filename: visible and selectable; no `Invalid image file!`; normal update confirmation reached
- Redundant second flash intentionally not performed after validation reached confirmation

## Scope

Exactly three files:
- `m1_csrc/m1_file_browser.c`
- `m1_csrc/m1_storage.c`
- `m1_csrc/m1_storage.h`
